### PR TITLE
Strip empty strings from pageName list.

### DIFF
--- a/components/cpx-reporter/reporter.js
+++ b/components/cpx-reporter/reporter.js
@@ -18,7 +18,7 @@ const eventMap = new Map([
                         "errorType": "",
                         "gated": "",
                         "pageCategory": "",
-                        pageName: data ? [data['siteName'], data['pageCategory'], data['subsection'], data['subsection2'], data['subsection3'], data['lastUrlItem']].filter(v => (typeof v !== 'undefined' && v !== null)).join('|') : '',
+                        pageName: data ? [data['siteName'], data['pageCategory'], data['subsection'], data['subsection2'], data['subsection3'], data['lastUrlItem']].filter(v => (typeof v !== 'undefined' && v !== null && v !== '')).join('|') : '',
                         "siteName": "",
                         "pageTitle": "",
                         "pageType": "",

--- a/components/cpx-reporter/src/reporter.ts
+++ b/components/cpx-reporter/src/reporter.ts
@@ -20,7 +20,7 @@ const eventMap = new Map([
           "pageCategory": "", // technologies
           // Build pageName to match format:
           // [siteName]|[primary Category]|[subcategory1]|[subcategory2]|[subcategory3]|[subcategory4]|[page detail name]
-          pageName: data ? [data['siteName'],data['pageCategory'], data['subsection'], data['subsection2'], data['subsection3'], data['lastUrlItem']].filter(v=>(typeof v !== 'undefined' && v !== null)).join('|'): '',
+          pageName: data ? [data['siteName'],data['pageCategory'], data['subsection'], data['subsection2'], data['subsection3'], data['lastUrlItem']].filter(v=>(typeof v !== 'undefined' && v !== null && v !== '')).join('|'): '',
           "siteName": "",
           "pageTitle": "", //Red Hat Enterprise Linux operating system
           "pageType": "", // pattern_template


### PR DESCRIPTION
This PR strips empty strings from the list of items that builds `pageName`. E.g., changes it from `'RHC|benefits-of-being-a-partner|||'` to `'RHC|benefits-of-being-a-partner'`.